### PR TITLE
Medium Tan color name added

### DIFF
--- a/app/js/bricklink-colors.js
+++ b/app/js/bricklink-colors.js
@@ -445,7 +445,7 @@ let ALL_BRICKLINK_SOLID_COLORS = [
     // },
     {
         name: "Medium Tan",
-        hex: "#D9C594",
+        hex: "#d9c594",
         id: 241,
     },
 ];
@@ -521,6 +521,7 @@ const KNOWN_BRICKLINK_STUD_COLOR_NAMES = [
     "Glow In Dark White",
     "Medium Lavender", // manually added from Batman
     "Light Aqua", // manually added from Batman
+    "Medium Tan",// manually added
 ];
 
 const KNOWN_BRICKLINK_TILE_COLOR_NAMES = [


### PR DESCRIPTION
The name of the "Medium Tan" color does not appear in step 4 or in the instructions, only the hex code appears.

![image](https://github.com/debkbanerji/lego-art-remix/assets/169965703/27033dd2-7efe-4960-babd-9795c8d6184a)

So, Medium Tan was added to the color list, so it could be displayed correctly in step 4 and in the instructions.

![image](https://github.com/debkbanerji/lego-art-remix/assets/169965703/3226e86e-24d6-4131-91ac-c4ec20cce6ac)
